### PR TITLE
Add Agent builder section with langgraph4j

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,5 @@ Let’s put Kotlin on the AI map! 💜🤖
 ## MCP 
 - [kotlin-sdk](https://github.com/modelcontextprotocol/kotlin-sdk) - The official Kotlin SDK for Model Context Protocol servers and clients. Maintained in collaboration with JetBrains
 
+## Agent builder
+- [langgraph4j](https://github.com/bsorrentino/langgraph4j) - Java version of [Langgraph](https://www.langchain.com/langgraph) which is built for work with [langchain4j](https://github.com/langchain4j/langchain4j)


### PR DESCRIPTION
While LlamaIndex and LangGraph shine in JavaScript and Python, Java/Kotlin agent-building options were limited—until **LangGraph4j**. Paired with LangChain4j, **LangGraph4j** empowers Java/Kotlin developers to craft advanced AI agents effortlessly, closing the ecosystem gap.